### PR TITLE
Update buildings.json

### DIFF
--- a/buildings.json
+++ b/buildings.json
@@ -387,7 +387,7 @@
     "italian": "Fabbrica di unità di controllo IA",
 	  "spanish":"Fábrica de unidades de control de IA",
 	  "japanese": "AI制御ユニット生産工場",
-	  "polish": "Fabryka paneli kontrolnych AI",
+	  "polish": "Fabryka kontrolerów AI",
 	  "czech": "Továrna na kontrolní jednotky umělé inteligence",
   },
 
@@ -489,7 +489,7 @@
     "spanish": "Centro de Reciclaje",
     "italian": "Centro di Riciclaggio",
 	  "japanese": "リサイクル工場",
-	  "polish": "Centrum recyklingowe",
+	  "polish": "Centrum recyklingu",
 	  "czech": "Recyklační centrum",
   },
   "soilEnrichmentFacility": {
@@ -661,7 +661,7 @@
     "spanish": "Torre Residencial",
     "italian": "Torre Residenziale",
 	  "japanese": "住宅用高層ビル",
-	  "polish": "Wierzowiec mieszkalny",
+	  "polish": "Wieżowiec mieszkalny",
 	  "czech": "Panelák",
   },
 	"habitatLevel6": {
@@ -673,7 +673,7 @@
     "spanish": "Torre Residencial de Lujo",
     "italian": "Torre Residenziale di Lusso",
 		"japanese": "高級住宅用高層ビル",
-		"polish": "Luksusowy wierzowiec mieszkalny",
+		"polish": "Luksusowy wieżowiec mieszkalny",
 		"czech": "Luxusní věžák",
   },
 
@@ -820,7 +820,7 @@
 	"spanish": "Excavadora Colosal de Adamantino",
     "italian": "Trivella colossale per adamantio",
 	  "japanese": "アダマンタイト採掘場",
-	  "polish": "Kolosalne adamantynowe wiertło",
+	  "polish": "Kolosalne wiertło adamantynowe",
 	  "czech": "Obři adamantinový vrták",
   }
 }


### PR DESCRIPTION
Changes in polish translation:
* `AI Control Unit Factory` translation aligned to a change proposed in `resources.json`.
* Although `Centrum recyklingowe` is correct translation, `Centrum recyklingu` is a far more popular form.
* Misspelled `wieżowiec` - fixed.
* `Adamantine Drill` is a proper name. Translation of `Collosal Adamantine Drill` has been modified to reflect that.